### PR TITLE
Ensure plan tool outputs are narrated with tool reported format

### DIFF
--- a/python/agents/voice-of-customer/README.md
+++ b/python/agents/voice-of-customer/README.md
@@ -44,6 +44,21 @@ erro descritivos (`plan_parsing_error`, `plan_not_found`, `task_not_found`),
 garantindo que o supervisor consiga reagir rapidamente a inconsistências do
 planner ou a ordens de execução inválidas.
 
+Para cumprir o protocolo de transparência da Avenue, toda vez que o supervisor
+apresentar o resultado de `store_supervisor_plan`, `mark_supervisor_task_completed`,
+`get_supervisor_plan_status` ou `reset_supervisor_plan` ao usuário, ele deve
+preservar a mensagem literal retornada pelo tool usando o formato
+`[NomeDaFerramenta] tool reported: ...`. O helper
+`format_plan_tool_status(tool_name, response)` centraliza essa formatação e
+gera textos como:
+
+```
+store_supervisor_plan tool reported: Plano registrado no estado do supervisor. Total de tarefas registradas: 5. Pendentes: 5. Etapas no plano: 2.
+```
+
+Ao utilizar essa string diretamente na conversa, o usuário tem visibilidade
+completa do que cada ferramenta reportou.
+
 
 ## Testes
 

--- a/python/agents/voice-of-customer/tests/test_plan_management_tools.py
+++ b/python/agents/voice-of-customer/tests/test_plan_management_tools.py
@@ -49,12 +49,25 @@ def test_store_plan_invalid_json_returns_error(tool_context) -> None:
     assert response["error"] == "plan_parsing_error"
     assert PLAN_STATE_KEY not in tool_context.state
 
+    narrated = plan_management.format_plan_tool_status(
+        "store_supervisor_plan", response
+    )
+    assert narrated.startswith("store_supervisor_plan tool reported:")
+    assert "plan parsing" not in narrated.lower()  # ensure Portuguese message is surfaced
+    assert "Não foi possível interpretar o plano" in narrated
+
 
 def test_mark_task_completed_without_plan_returns_error(tool_context) -> None:
     response = plan_management.mark_supervisor_task_completed("1", tool_context)
 
     assert response["status"] == "error"
     assert response["error"] == "plan_not_found"
+
+    narrated = plan_management.format_plan_tool_status(
+        "mark_supervisor_task_completed", response
+    )
+    assert narrated.startswith("mark_supervisor_task_completed tool reported:")
+    assert response["message"] in narrated
 
 
 def test_mark_task_completed_invalid_order_returns_error(tool_context) -> None:
@@ -66,6 +79,11 @@ def test_mark_task_completed_invalid_order_returns_error(tool_context) -> None:
     assert response["status"] == "error"
     assert response["error"] == "task_not_found"
 
+    narrated = plan_management.format_plan_tool_status(
+        "mark_supervisor_task_completed", response
+    )
+    assert "A tarefa informada não existe" in narrated
+
 
 def test_get_plan_status_reports_absence_of_plan(tool_context) -> None:
     status = plan_management.get_supervisor_plan_status(tool_context)
@@ -74,3 +92,9 @@ def test_get_plan_status_reports_absence_of_plan(tool_context) -> None:
     assert status["has_plan"] is False
     assert status["summary"]["total_tasks"] == 0
     assert "Nenhum plano ativo" in status["markdown"]
+
+    narrated = plan_management.format_plan_tool_status(
+        "get_supervisor_plan_status", status
+    )
+    assert narrated.startswith("get_supervisor_plan_status tool reported:")
+    assert "Nenhum plano ativo" in narrated

--- a/python/agents/voice-of-customer/voice_of_customer/prompt.py
+++ b/python/agents/voice-of-customer/voice_of_customer/prompt.py
@@ -78,6 +78,11 @@ Fluxo obrigatório para análises:
    - Utilize `get_supervisor_plan_status` para confirmar as etapas
      registradas e, quando fizer sentido, compartilhar um resumo do plano
      com o usuário antes de iniciar a execução.
+   - Sempre que repassar ao usuário a saída de `store_supervisor_plan`,
+     `mark_supervisor_task_completed`, `get_supervisor_plan_status` ou
+     `reset_supervisor_plan`, utilize exatamente o padrão
+     `[NomeDaFerramenta] tool reported: [resultado integral do tool]`. Isso
+     garante que o usuário receba o texto bruto reportado pela ferramenta.
 
 2. **ESCLARECIMENTOS (se necessário):**
    - Se o *planner* solicitar informações adicionais, colete do usuário, mas não repasse ao usuário a fala literal que o *planner* trouxe para você.
@@ -104,7 +109,9 @@ Fluxo obrigatório para análises:
      correspondente.
    - Sempre que precisar acompanhar o progresso ou reportar status ao
      usuário, consulte `get_supervisor_plan_status` e traduza o resumo em
-     linguagem natural.
+     linguagem natural SEMPRE preservando o padrão
+     `[get_supervisor_plan_status tool reported: ...]` ao compartilhar a
+     saída com o usuário.
 
 4. **ENTREGA FINAL:**
    - Sempre acione obrigatoriamente o *reporter_agent*

--- a/python/agents/voice-of-customer/voice_of_customer/tools/plan_management.py
+++ b/python/agents/voice-of-customer/voice_of_customer/tools/plan_management.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from typing import Any
 
 from google.adk.tools import ToolContext
@@ -129,9 +130,108 @@ def reset_supervisor_plan(tool_context: ToolContext) -> dict[str, Any]:
     }
 
 
+def format_plan_tool_status(
+    tool_name: str, response: dict[str, Any]
+) -> str:
+    """Formats tool responses so the supervisor can narrate them consistently.
+
+    The Avenue Deep Dive supervisor must read back the outputs of plan
+    management tools to the user using the pattern
+    ``"[tool_name] tool reported: ..."``.  This helper extracts the most
+    relevant fields from ``response`` to build that narration, falling back to a
+    JSON representation when a more specific summary is not available.
+
+    Args:
+        tool_name: Name of the tool that produced ``response``.
+        response: Dictionary returned by a plan management tool.
+
+    Returns:
+        A natural-language string ready to be surfaced to the user.
+    """
+
+    highlight_parts: list[str] = []
+
+    message = response.get("message")
+    if isinstance(message, str) and message:
+        highlight_parts.append(message.strip())
+
+    if response.get("status") == "error":
+        detail = response.get("detail")
+        if isinstance(detail, str) and detail:
+            highlight_parts.append(f"Detalhe: {detail.strip()}")
+        highlight_text = " ".join(part for part in highlight_parts if part)
+        if not highlight_text:
+            highlight_text = json.dumps(response, ensure_ascii=False)
+        return f"{tool_name} tool reported: {highlight_text}"
+
+    if tool_name == "store_supervisor_plan":
+        total_tasks = response.get("total_tasks")
+        pending_tasks = response.get("pending_tasks")
+        total_stages = response.get("total_stages") or response.get("stages")
+        if total_tasks is not None and pending_tasks is not None:
+            highlight_parts.append(
+                f"Total de tarefas registradas: {total_tasks}."
+                f" Pendentes: {pending_tasks}."
+            )
+        if total_stages is not None:
+            highlight_parts.append(f"Etapas no plano: {total_stages}.")
+    elif tool_name == "mark_supervisor_task_completed":
+        execution_order = response.get("execution_order")
+        total_completed = response.get("total_completed")
+        remaining_tasks = response.get("remaining_tasks")
+        completed_stages = response.get("completed_stages")
+        if execution_order is not None:
+            highlight_parts.append(
+                f"Tarefa {execution_order} marcada como concluída."
+            )
+        if total_completed is not None and remaining_tasks is not None:
+            highlight_parts.append(
+                f"Andamento: {total_completed} concluídas,"
+                f" {remaining_tasks} pendentes."
+            )
+        if completed_stages is not None:
+            highlight_parts.append(f"Etapas concluídas: {completed_stages}.")
+    elif tool_name == "get_supervisor_plan_status":
+        summary = response.get("summary")
+        if isinstance(summary, dict):
+            total_tasks = summary.get("total_tasks")
+            completed_tasks = summary.get("completed_tasks")
+            remaining_tasks = summary.get("remaining_tasks")
+            total_stages = summary.get("total_stages")
+            completed_stages = summary.get("completed_stages")
+            if (
+                total_tasks is not None
+                and completed_tasks is not None
+                and remaining_tasks is not None
+            ):
+                highlight_parts.append(
+                    "Status atual: "
+                    f"{completed_tasks}/{total_tasks} tarefas concluídas"
+                    f" ({remaining_tasks} pendentes)."
+                )
+            if total_stages is not None and completed_stages is not None:
+                highlight_parts.append(
+                    f"Etapas concluídas: {completed_stages} de {total_stages}."
+                )
+        markdown = response.get("markdown")
+        if isinstance(markdown, str) and markdown:
+            highlight_parts.append(f"Resumo formatado:\n{markdown.strip()}")
+    elif tool_name == "reset_supervisor_plan":
+        # Message already covers the important status information.
+        pass
+    else:
+        highlight_parts.append(json.dumps(response, ensure_ascii=False))
+
+    highlight_text = " ".join(part.strip() for part in highlight_parts if part)
+    if not highlight_text:
+        highlight_text = json.dumps(response, ensure_ascii=False)
+    return f"{tool_name} tool reported: {highlight_text}"
+
+
 __all__ = [
     "PlanParsingError",
     "TaskNotFoundError",
+    "format_plan_tool_status",
     "get_supervisor_plan_status",
     "mark_supervisor_task_completed",
     "reset_supervisor_plan",


### PR DESCRIPTION
## Summary
- require the supervisor prompt and README instructions to share plan tool outputs using the `[Tool] tool reported:` pattern
- add a `format_plan_tool_status` helper so plan management responses include consistent narration-ready text
- extend plan-management tests to assert that formatted status text surfaces the underlying tool responses

## Testing
- `cd python/agents/voice-of-customer && pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d560b8dab88322970417506b019b1a