### PR TITLE
Add shared state utilities and persistence tools for VoC

### DIFF
--- a/python/agents/voice-of-customer/README.md
+++ b/python/agents/voice-of-customer/README.md
@@ -45,6 +45,43 @@ garantindo que o supervisor consiga reagir rapidamente a inconsistências do
 planner ou a ordens de execução inválidas.
 
 
+## Contrato de Estado Compartilhado
+
+O módulo [`shared/state.py`](voice_of_customer/shared/state.py) centraliza o
+estado compartilhado utilizado pelos subagentes. Ele inicializa a sessão com
+uma estrutura padrão contendo:
+
+- `plan_metadata`: metadados sobre o pedido em andamento (resumo, período,
+  audiência alvo).
+- `collected_datasets`: lista de datasets agregados e anonimizados coletados
+  pelo `data_collector_agent`.
+- `quantitative_insights`: resumo e métricas estruturadas geradas pelo
+  `quanti_analyst_agent`.
+- `qualitative_insights`: resumo, temas e citações representativas compiladas
+  pelo `quali_analyst_agent`.
+- `reporter_handoff`: informações finais para o `reporter_agent`, incluindo o
+  status do hand-off, entregáveis e próximos passos.
+
+O `root_agent` registra o callback `load_default_state` como
+`before_agent_callback`, garantindo que a estrutura seja carregada antes da
+primeira interação e permitindo carregar fixtures (via variável de ambiente
+`VOICE_OF_CUSTOMER_SCENARIO`) para demos ou testes.
+
+Para simplificar a persistência de resultados, expomos ferramentas em
+[`tools/shared_state.py`](voice_of_customer/tools/shared_state.py):
+
+- `record_plan_metadata`
+- `record_dataset`
+- `record_quanti_summary`
+- `record_quali_summary`
+- `record_reporter_handoff`
+- `get_reporter_snapshot`
+
+Essas funções padronizam a gravação no `ToolContext.state` e retornam metadados
+úteis (quantidade de datasets, contagem de métricas, status do hand-off etc.),
+facilitando a coordenação entre os subagentes.
+
+
 ## Testes
 
 Execute os testes unitários com:

--- a/python/agents/voice-of-customer/tests/_tool_context_stub.py
+++ b/python/agents/voice-of-customer/tests/_tool_context_stub.py
@@ -26,6 +26,43 @@ def ensure_tool_context_stub() -> None:
         adk_module = sys.modules["google.adk"]
         setattr(google_module, "adk", adk_module)
 
+    if "google.adk.agents" not in sys.modules:  # pragma: no cover - module import guard
+        agents_module = types.ModuleType("google.adk.agents")
+
+        class _StubLlmAgent:
+            """Lightweight replacement that stores init kwargs as attributes."""
+
+            def __init__(self, *args: Any, **kwargs: Any) -> None:  # noqa: D401 - simple stub
+                self._args = args
+                self._kwargs = kwargs
+                for key, value in kwargs.items():
+                    setattr(self, key, value)
+
+        agents_module.LlmAgent = _StubLlmAgent
+        agents_module.__all__ = ["LlmAgent"]
+        sys.modules["google.adk.agents"] = agents_module
+        setattr(adk_module, "agents", agents_module)
+    else:  # pragma: no cover - reuse existing module
+        agents_module = sys.modules["google.adk.agents"]
+        setattr(adk_module, "agents", agents_module)
+
+    if "google.adk.agents.callback_context" not in sys.modules:  # pragma: no cover
+        callback_module = types.ModuleType("google.adk.agents.callback_context")
+
+        class _StubCallbackContext:
+            """Minimal callback context exposing a mutable state mapping."""
+
+            def __init__(self) -> None:
+                self.state: dict[str, Any] = {}
+
+        callback_module.CallbackContext = _StubCallbackContext
+        callback_module.__all__ = ["CallbackContext"]
+        sys.modules["google.adk.agents.callback_context"] = callback_module
+        setattr(agents_module, "callback_context", callback_module)
+    else:  # pragma: no cover - reuse existing module when provided by environment
+        callback_module = sys.modules["google.adk.agents.callback_context"]
+        setattr(agents_module, "callback_context", callback_module)
+
     if "google.adk.tools" not in sys.modules:  # pragma: no cover - module import guard
         tools_module = types.ModuleType("google.adk.tools")
 
@@ -35,13 +72,44 @@ def ensure_tool_context_stub() -> None:
             def __init__(self) -> None:
                 self.state: dict[str, Any] = {}
 
+        class _StubFunctionTool:
+            """No-op FunctionTool that proxies calls to the wrapped function."""
+
+            def __init__(self, func: Any, *args: Any, **kwargs: Any) -> None:  # noqa: D401
+                self.func = func
+                self._args = args
+                self._kwargs = kwargs
+
+            def __call__(self, *args: Any, **kwargs: Any) -> Any:
+                return self.func(*args, **kwargs)
+
         tools_module.ToolContext = _StubToolContext
-        tools_module.__all__ = ["ToolContext"]
+        tools_module.FunctionTool = _StubFunctionTool
+        tools_module.__all__ = ["ToolContext", "FunctionTool"]
         sys.modules["google.adk.tools"] = tools_module
         setattr(adk_module, "tools", tools_module)
     else:  # pragma: no cover - reuse existing module
         tools_module = sys.modules["google.adk.tools"]
         setattr(adk_module, "tools", tools_module)
+
+    if "google.adk.tools.agent_tool" not in sys.modules:  # pragma: no cover
+        agent_tool_module = types.ModuleType("google.adk.tools.agent_tool")
+
+        class _StubAgentTool:
+            """Stores a reference to the delegated agent."""
+
+            def __init__(self, agent: Any, *args: Any, **kwargs: Any) -> None:  # noqa: D401
+                self.agent = agent
+                self._args = args
+                self._kwargs = kwargs
+
+        agent_tool_module.AgentTool = _StubAgentTool
+        agent_tool_module.__all__ = ["AgentTool"]
+        sys.modules["google.adk.tools.agent_tool"] = agent_tool_module
+        setattr(tools_module, "agent_tool", agent_tool_module)
+    else:  # pragma: no cover - reuse existing module when provided by environment
+        agent_tool_module = sys.modules["google.adk.tools.agent_tool"]
+        setattr(tools_module, "agent_tool", agent_tool_module)
 
 
 def get_tool_context_class() -> Type[Any]:

--- a/python/agents/voice-of-customer/tests/fixtures/demo_state.json
+++ b/python/agents/voice-of-customer/tests/fixtures/demo_state.json
@@ -1,0 +1,46 @@
+{
+  "state": {
+    "plan_metadata": {
+      "request_summary": "Diagnóstico do onboarding digital",
+      "timeframe": "Último trimestre",
+      "audience": "Liderança de CX"
+    },
+    "collected_datasets": [
+      {
+        "name": "nps_trend_dataset",
+        "timeframe": "2024-Q1",
+        "metrics": {
+          "nps": 48.0,
+          "response_count": 3200
+        }
+      }
+    ],
+    "quantitative_insights": {
+      "summary": "NPS caiu 6 pontos no trimestre com destaque para detratores em onboarding.",
+      "metrics": [
+        {
+          "name": "NPS",
+          "value": 48.0
+        }
+      ]
+    },
+    "qualitative_insights": {
+      "summary": "Clientes relatam fricção no envio de documentos e espera por aprovação.",
+      "themes": [
+        "Documentação",
+        "Tempo de aprovação"
+      ],
+      "representative_quotes": [
+        "\"Demorou muito para aprovarem minha conta.\""
+      ]
+    },
+    "reporter_handoff": {
+      "status": "ready",
+      "final_deliverable": "Relatório executivo preparado",
+      "next_steps": [
+        "Agendar apresentação com liderança",
+        "Validar plano de ação proposto"
+      ]
+    }
+  }
+}

--- a/python/agents/voice-of-customer/tests/test_shared_state_module.py
+++ b/python/agents/voice-of-customer/tests/test_shared_state_module.py
@@ -1,0 +1,92 @@
+"""Tests covering the shared state utilities."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+# Importing the stub ensures the lightweight google.adk modules are available.
+from ._tool_context_stub import get_tool_context_class  # noqa: E402  # isort: skip
+
+# Ensure package is importable regardless of pytest working directory
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from voice_of_customer.shared import state as shared_state  # noqa: E402  # isort: skip
+
+
+FIXTURE_PATH = (
+    Path(__file__).resolve().parents[0] / "fixtures" / "demo_state.json"
+)
+
+
+def test_ensure_default_state_initializes_missing_keys() -> None:
+    state: dict[str, object] = {}
+
+    shared_state.ensure_default_state(state)
+
+    defaults = shared_state.default_state()
+    for key in defaults:
+        assert key in state
+        assert state[key] == defaults[key]
+
+
+def test_initialize_state_applies_fixture(tmp_path: Path) -> None:
+    fixture_data = {
+        "state": {
+            shared_state.SharedStateKeys.PLAN_METADATA: {
+                "request_summary": "Revisar onboarding",
+                "audience": "Diretoria",
+            },
+            shared_state.SharedStateKeys.REPORTER_HANDOFF: {
+                "status": "ready",
+                "final_deliverable": "Deck pronto",
+            },
+        }
+    }
+    fixture_path = tmp_path / "fixture.json"
+    fixture_path.write_text(json.dumps(fixture_data), encoding="utf-8")
+
+    state: dict[str, object] = {}
+    shared_state.initialize_state(state, fixture=fixture_data["state"])
+
+    assert state[shared_state.SharedStateKeys.PLAN_METADATA]["audience"] == "Diretoria"
+    assert (
+        state[shared_state.SharedStateKeys.REPORTER_HANDOFF]["final_deliverable"]
+        == "Deck pronto"
+    )
+
+
+def test_before_agent_callback_loads_defaults_and_fixture(monkeypatch: pytest.MonkeyPatch) -> None:
+    from google.adk.agents.callback_context import CallbackContext
+
+    monkeypatch.setenv(shared_state.SCENARIO_ENV_VAR, str(FIXTURE_PATH))
+
+    context = CallbackContext()
+    shared_state.load_default_state(context)
+
+    assert (
+        context.state[shared_state.SharedStateKeys.PLAN_METADATA]["request_summary"]
+        == "Diagnóstico do onboarding digital"
+    )
+    assert context.state[shared_state.SharedStateKeys.COLLECTED_DATASETS]
+
+
+def test_root_agent_registers_before_agent_callback(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(shared_state.SCENARIO_ENV_VAR, str(FIXTURE_PATH))
+
+    from voice_of_customer.agent import root_agent
+    from google.adk.agents.callback_context import CallbackContext
+
+    assert callable(root_agent.before_agent_callback)
+
+    # Ensure the stub modules are initialised for downstream imports.
+    get_tool_context_class()
+
+    callback_context = CallbackContext()
+    root_agent.before_agent_callback(callback_context)
+
+    assert callback_context.state[shared_state.SharedStateKeys.COLLECTED_DATASETS]
+

--- a/python/agents/voice-of-customer/tests/test_shared_state_tools.py
+++ b/python/agents/voice-of-customer/tests/test_shared_state_tools.py
@@ -1,0 +1,90 @@
+"""Unit tests for the shared state helper tools."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from ._tool_context_stub import get_tool_context_class  # noqa: E402  # isort: skip
+
+# Ensure package imports resolve regardless of pytest working dir
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from voice_of_customer.shared.state import SharedStateKeys  # noqa: E402  # isort: skip
+from voice_of_customer.tools import (  # noqa: E402  # isort: skip
+    get_reporter_snapshot,
+    record_dataset,
+    record_plan_metadata,
+    record_quali_summary,
+    record_quanti_summary,
+    record_reporter_handoff,
+)
+
+
+@pytest.fixture()
+def tool_context():
+    tool_context_cls = get_tool_context_class()
+    return tool_context_cls()
+
+
+def test_recorders_update_state_and_return_status(tool_context) -> None:
+    metadata_response = record_plan_metadata(
+        {"request_summary": "Análise churn", "audience": "CS"},
+        tool_context,
+    )
+    assert metadata_response["status"] == "plan_metadata_recorded"
+
+    dataset_response = record_dataset(
+        {"name": "nps_dataset", "timeframe": "2024-Q1"},
+        tool_context,
+    )
+    assert dataset_response["status"] == "dataset_recorded"
+    assert dataset_response["total_datasets"] == 1
+
+    quant_response = record_quanti_summary(
+        "NPS caiu 5 pontos",
+        {"nps": 42.0, "csat": 4.5},
+        tool_context,
+    )
+    assert quant_response["status"] == "quant_summary_recorded"
+    assert quant_response["metrics_count"] == 2
+
+    quali_response = record_quali_summary(
+        "Sentimento negativo em onboarding",
+        ["Onboarding", "Suporte"],
+        ["Processo demorado"],
+        tool_context,
+    )
+    assert quali_response["status"] == "qual_summary_recorded"
+    assert quali_response["themes_count"] == 2
+    assert quali_response["quotes_count"] == 1
+
+    handoff_response = record_reporter_handoff(
+        "Relatório executivo", ["Enviar para diretoria"], "ready", tool_context
+    )
+    assert handoff_response["status"] == "reporter_handoff_recorded"
+    assert handoff_response["handoff_ready"] is True
+
+    state = tool_context.state
+    assert state[SharedStateKeys.COLLECTED_DATASETS][0]["name"] == "nps_dataset"
+    assert state[SharedStateKeys.QUANT_INSIGHTS]["metrics"][0]["name"] == "nps"
+    assert "Processo demorado" in state[SharedStateKeys.QUAL_INSIGHTS][
+        "representative_quotes"
+    ]
+    assert state[SharedStateKeys.REPORTER_HANDOFF]["status"] == "ready"
+
+
+def test_reporter_snapshot_reflects_recorded_entries(tool_context) -> None:
+    record_dataset({"name": "csat_dataset"}, tool_context)
+    record_quanti_summary("CSAT estável", None, tool_context)
+    record_quali_summary("Clientes satisfeitos", ["Suporte"], None, tool_context)
+    record_reporter_handoff("Resumo enviado", ["Coletar feedback"], "completed", tool_context)
+
+    snapshot = get_reporter_snapshot(tool_context)
+
+    assert snapshot[SharedStateKeys.COLLECTED_DATASETS][0]["name"] == "csat_dataset"
+    assert snapshot[SharedStateKeys.QUANT_INSIGHTS]["summary"] == "CSAT estável"
+    assert snapshot[SharedStateKeys.QUAL_INSIGHTS]["themes"] == ["Suporte"]
+    assert snapshot[SharedStateKeys.REPORTER_HANDOFF]["status"] == "completed"

--- a/python/agents/voice-of-customer/voice_of_customer/agent.py
+++ b/python/agents/voice-of-customer/voice_of_customer/agent.py
@@ -9,6 +9,7 @@ from google.adk.tools import FunctionTool
 from google.adk.tools.agent_tool import AgentTool
 
 from . import prompt
+from .shared.state import load_default_state
 from .sub_agents.data_collector.agent import data_collector_agent
 from .sub_agents.planner.agent import planner_agent
 from .sub_agents.quali.agent import quali_analyst_agent
@@ -41,6 +42,7 @@ supervisor_agent = LlmAgent(
         AgentTool(agent=quali_analyst_agent),
         AgentTool(agent=reporter_agent),
     ],
+    before_agent_callback=load_default_state,
 )
 
 root_agent = supervisor_agent

--- a/python/agents/voice-of-customer/voice_of_customer/shared/state.py
+++ b/python/agents/voice-of-customer/voice_of_customer/shared/state.py
@@ -1,0 +1,141 @@
+"""Utilities for initializing and managing shared VoC session state."""
+
+from __future__ import annotations
+
+import copy
+import json
+import os
+from dataclasses import dataclass
+from typing import Any, Mapping, MutableMapping
+
+from google.adk.agents.callback_context import CallbackContext
+
+SCENARIO_ENV_VAR = "VOICE_OF_CUSTOMER_SCENARIO"
+
+
+@dataclass(frozen=True)
+class SharedStateKeys:
+    """Canonical keys used by sub-agents to exchange information."""
+
+    PLAN_METADATA: str = "plan_metadata"
+    COLLECTED_DATASETS: str = "collected_datasets"
+    QUANT_INSIGHTS: str = "quantitative_insights"
+    QUAL_INSIGHTS: str = "qualitative_insights"
+    REPORTER_HANDOFF: str = "reporter_handoff"
+
+
+def default_state() -> dict[str, Any]:
+    """Returns a fresh copy of the default shared state structure."""
+
+    return {
+        SharedStateKeys.PLAN_METADATA: {
+            "request_summary": "",
+            "timeframe": "",
+            "audience": "",
+        },
+        SharedStateKeys.COLLECTED_DATASETS: [],
+        SharedStateKeys.QUANT_INSIGHTS: {
+            "summary": "",
+            "metrics": [],
+        },
+        SharedStateKeys.QUAL_INSIGHTS: {
+            "summary": "",
+            "themes": [],
+            "representative_quotes": [],
+        },
+        SharedStateKeys.REPORTER_HANDOFF: {
+            "status": "pending",
+            "final_deliverable": "",
+            "next_steps": [],
+        },
+    }
+
+
+def ensure_default_state(state: MutableMapping[str, Any]) -> MutableMapping[str, Any]:
+    """Ensures that ``state`` contains all expected shared-state keys."""
+
+    defaults = default_state()
+    for key, value in defaults.items():
+        if key not in state:
+            state[key] = copy.deepcopy(value)
+            continue
+
+        if isinstance(value, dict) and isinstance(state[key], MutableMapping):
+            for nested_key, nested_value in value.items():
+                state[key].setdefault(nested_key, copy.deepcopy(nested_value))
+
+    return state
+
+
+def _deep_update(target: MutableMapping[str, Any], updates: Mapping[str, Any]) -> None:
+    """Performs a deep update of ``target`` with ``updates``."""
+
+    for key, value in updates.items():
+        if isinstance(value, Mapping) and isinstance(target.get(key), MutableMapping):
+            _deep_update(target[key], value)
+        else:
+            target[key] = copy.deepcopy(value)
+
+
+def initialize_state(
+    state: MutableMapping[str, Any], fixture: Mapping[str, Any] | None = None
+) -> MutableMapping[str, Any]:
+    """Initializes ``state`` with defaults and optional fixture data."""
+
+    ensure_default_state(state)
+    if fixture:
+        _deep_update(state, fixture)
+    return state
+
+
+def _load_fixture(path: str) -> Mapping[str, Any]:
+    """Loads a fixture file returning the contained state mapping."""
+
+    with open(path, "r", encoding="utf-8") as file:
+        payload = json.load(file)
+    if isinstance(payload, Mapping) and "state" in payload:
+        state_payload = payload["state"]
+        if isinstance(state_payload, Mapping):
+            return state_payload
+    if not isinstance(payload, Mapping):  # pragma: no cover - sanity guard
+        raise ValueError("Fixture payload must be a mapping")
+    return payload
+
+
+def load_default_state(callback_context: CallbackContext) -> None:
+    """Callback that seeds the shared state before the supervisor runs."""
+
+    fixture_path = os.getenv(SCENARIO_ENV_VAR)
+    fixture_data: Mapping[str, Any] | None = None
+    if fixture_path:
+        fixture_data = _load_fixture(fixture_path)
+
+    initialize_state(callback_context.state, fixture=fixture_data)
+
+
+def build_reporter_snapshot(state: Mapping[str, Any]) -> dict[str, Any]:
+    """Returns an immutable snapshot that the reporter can safely consume."""
+
+    snapshot = {}
+    defaults = default_state()
+    for key, default_value in defaults.items():
+        if key not in state:
+            snapshot[key] = copy.deepcopy(default_value)
+            continue
+        value = state[key]
+        if isinstance(value, Mapping):
+            snapshot[key] = copy.deepcopy(dict(value))
+        else:
+            snapshot[key] = copy.deepcopy(value)
+    return snapshot
+
+
+__all__ = [
+    "SharedStateKeys",
+    "SCENARIO_ENV_VAR",
+    "default_state",
+    "ensure_default_state",
+    "initialize_state",
+    "load_default_state",
+    "build_reporter_snapshot",
+]

--- a/python/agents/voice-of-customer/voice_of_customer/tools/__init__.py
+++ b/python/agents/voice-of-customer/voice_of_customer/tools/__init__.py
@@ -1,0 +1,19 @@
+"""Tool namespace for the Voice of Customer agent."""
+
+from .shared_state import (
+    get_reporter_snapshot,
+    record_dataset,
+    record_plan_metadata,
+    record_quali_summary,
+    record_quanti_summary,
+    record_reporter_handoff,
+)
+
+__all__ = [
+    "get_reporter_snapshot",
+    "record_dataset",
+    "record_plan_metadata",
+    "record_quali_summary",
+    "record_quanti_summary",
+    "record_reporter_handoff",
+]

--- a/python/agents/voice-of-customer/voice_of_customer/tools/shared_state.py
+++ b/python/agents/voice-of-customer/voice_of_customer/tools/shared_state.py
@@ -1,0 +1,190 @@
+"""Tools that manage shared Voice of Customer session state."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, MutableMapping, Sequence
+from typing import Any
+
+from google.adk.tools import ToolContext
+
+from ..shared.state import (
+    SharedStateKeys,
+    build_reporter_snapshot,
+    ensure_default_state,
+)
+
+
+def record_plan_metadata(
+    metadata: Mapping[str, Any], tool_context: ToolContext
+) -> dict[str, Any]:
+    """Stores planner metadata emitted by the supervisor or planner."""
+
+    ensure_default_state(tool_context.state)
+    if not isinstance(metadata, Mapping):
+        return {"status": "error", "error": "metadata_must_be_mapping"}
+
+    plan_metadata = _get_mutable_dict(
+        tool_context.state, SharedStateKeys.PLAN_METADATA
+    )
+    plan_metadata.update(dict(metadata))
+    return {
+        "status": "plan_metadata_recorded",
+        "metadata": dict(plan_metadata),
+    }
+
+
+def record_dataset(dataset: Mapping[str, Any], tool_context: ToolContext) -> dict[str, Any]:
+    """Registers a dataset collected by the data_collector_agent."""
+
+    ensure_default_state(tool_context.state)
+    if not isinstance(dataset, Mapping):
+        return {"status": "error", "error": "dataset_must_be_mapping"}
+
+    dataset_entry = dict(dataset)
+    dataset_name = str(dataset_entry.get("name", "")).strip()
+    if not dataset_name:
+        return {"status": "error", "error": "dataset_name_required"}
+    dataset_entry["name"] = dataset_name
+
+    datasets = _get_mutable_list(
+        tool_context.state, SharedStateKeys.COLLECTED_DATASETS
+    )
+    for index, existing in enumerate(datasets):
+        if isinstance(existing, Mapping) and existing.get("name") == dataset_name:
+            datasets[index] = dataset_entry
+            break
+    else:
+        datasets.append(dataset_entry)
+
+    return {
+        "status": "dataset_recorded",
+        "dataset": dataset_entry,
+        "total_datasets": len(datasets),
+    }
+
+
+def record_quanti_summary(
+    summary: str,
+    metrics: Mapping[str, Any] | Sequence[Mapping[str, Any]] | None,
+    tool_context: ToolContext,
+) -> dict[str, Any]:
+    """Stores quantitative analysis outputs."""
+
+    ensure_default_state(tool_context.state)
+    summary_text = str(summary).strip()
+    quant_state = _get_mutable_dict(
+        tool_context.state, SharedStateKeys.QUANT_INSIGHTS
+    )
+    quant_state["summary"] = summary_text
+    quant_state["metrics"] = _normalise_metrics(metrics)
+
+    return {
+        "status": "quant_summary_recorded",
+        "summary": summary_text,
+        "metrics_count": len(quant_state["metrics"]),
+    }
+
+
+def record_quali_summary(
+    summary: str,
+    themes: Sequence[str] | None,
+    representative_quotes: Sequence[str] | None,
+    tool_context: ToolContext,
+) -> dict[str, Any]:
+    """Stores qualitative insights such as themes and representative quotes."""
+
+    ensure_default_state(tool_context.state)
+    quali_state = _get_mutable_dict(
+        tool_context.state, SharedStateKeys.QUAL_INSIGHTS
+    )
+    quali_state["summary"] = str(summary).strip()
+    quali_state["themes"] = _normalise_string_sequence(themes)
+    quali_state["representative_quotes"] = _normalise_string_sequence(
+        representative_quotes
+    )
+
+    return {
+        "status": "qual_summary_recorded",
+        "themes_count": len(quali_state["themes"]),
+        "quotes_count": len(quali_state["representative_quotes"]),
+    }
+
+
+def record_reporter_handoff(
+    final_deliverable: str,
+    next_steps: Sequence[str] | None,
+    status: str,
+    tool_context: ToolContext,
+) -> dict[str, Any]:
+    """Persists the final reporter hand-off information."""
+
+    ensure_default_state(tool_context.state)
+    handoff_state = _get_mutable_dict(
+        tool_context.state, SharedStateKeys.REPORTER_HANDOFF
+    )
+    handoff_state["final_deliverable"] = str(final_deliverable).strip()
+    handoff_state["next_steps"] = _normalise_string_sequence(next_steps)
+    handoff_state["status"] = str(status).strip() or "pending"
+
+    return {
+        "status": "reporter_handoff_recorded",
+        "handoff_ready": handoff_state["status"].lower() in {"ready", "completed"},
+    }
+
+
+def get_reporter_snapshot(tool_context: ToolContext) -> dict[str, Any]:
+    """Returns an aggregated snapshot of the shared state for the reporter."""
+
+    ensure_default_state(tool_context.state)
+    return build_reporter_snapshot(tool_context.state)
+
+
+def _get_mutable_dict(state: MutableMapping[str, Any], key: str) -> MutableMapping[str, Any]:
+    value = state.get(key)
+    if not isinstance(value, MutableMapping):
+        value = {}
+        state[key] = value
+    return value
+
+
+def _get_mutable_list(state: MutableMapping[str, Any], key: str) -> list[Any]:
+    value = state.get(key)
+    if not isinstance(value, list):
+        value = []
+        state[key] = value
+    return value
+
+
+def _normalise_metrics(
+    metrics: Mapping[str, Any] | Sequence[Mapping[str, Any]] | None
+) -> list[dict[str, Any]]:
+    if metrics is None:
+        return []
+    if isinstance(metrics, Mapping):
+        return [
+            {"name": str(name), "value": value}
+            for name, value in metrics.items()
+        ]
+    if isinstance(metrics, Sequence):
+        normalised: list[dict[str, Any]] = []
+        for item in metrics:
+            if isinstance(item, Mapping):
+                normalised.append(dict(item))
+        return normalised
+    return []
+
+
+def _normalise_string_sequence(values: Sequence[str] | None) -> list[str]:
+    if not values:
+        return []
+    return [str(value).strip() for value in values if str(value).strip()]
+
+
+__all__ = [
+    "record_plan_metadata",
+    "record_dataset",
+    "record_quanti_summary",
+    "record_quali_summary",
+    "record_reporter_handoff",
+    "get_reporter_snapshot",
+]


### PR DESCRIPTION
## Summary
- add a shared state module that seeds plan metadata, datasets, quantitative/qualitative insights, and reporter hand-offs (with optional fixture loading)
- register the before-agent callback, expose helper tools for sub-agents to persist outputs, and extend the google.adk stubs used in tests
- document the shared state contract and cover the new utilities with focused regression tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d560bf02d88322b639f246ca3b6797