### PR TITLE
Add prerequisite checks before delegating analyses

### DIFF
--- a/python/agents/voice-of-customer/voice_of_customer/agent.py
+++ b/python/agents/voice-of-customer/voice_of_customer/agent.py
@@ -34,6 +34,7 @@ supervisor_agent = LlmAgent(
         FunctionTool(func=plan_management.store_supervisor_plan),
         FunctionTool(func=plan_management.mark_supervisor_task_completed),
         FunctionTool(func=plan_management.get_supervisor_plan_status),
+        FunctionTool(func=plan_management.ensure_next_task_ready),
         FunctionTool(func=plan_management.reset_supervisor_plan),
         AgentTool(agent=planner_agent),
         AgentTool(agent=data_collector_agent),

--- a/python/agents/voice-of-customer/voice_of_customer/prompt.py
+++ b/python/agents/voice-of-customer/voice_of_customer/prompt.py
@@ -99,6 +99,16 @@ Fluxo obrigatório para análises:
    - **NUNCA interrompa:** não gere outputs durante a execução
    - Antes de acionar um subagente, valide se a tarefa corresponde ao
      próximo item pendente no to-do registrado.
+   - Utilize a ferramenta `ensure_next_task_ready` para confirmar se o
+     próximo agente a ser acionado já está desbloqueado. O supervisor só
+     pode delegar atividades aos agentes de dados e análise depois de
+     marcar como concluídas todas as tarefas de esclarecimento sobre
+     datas, canais e objetivos.
+   - Caso o helper aponte pendências ou falta de dados, informe o usuário
+     exatamente o que está faltando, descreva as ações corretivas (por
+     exemplo: coletar datas faltantes, confirmar canais ou solicitar
+     coleta adicional de dados) e apenas avance após registrar a
+     conclusão no plano.
    - Ao concluir cada tarefa, utilize a ferramenta
      `mark_supervisor_task_completed` com o `execution_order`
      correspondente.
@@ -123,12 +133,15 @@ Fluxo obrigatório para análises:
 <CONSTRAINTS>  
 - **NUNCA** execute análises sem o *planner_agent* primeiro  
 - **LIMITAÇÃO DE DADOS:** Nunca aceite solicitações para períodos anteriores a 2020. Informe ao usuário sobre essa limitação.  
-- **NÃO** assuma responsabilidades dos *sub_agentes* especializados  
+- **NÃO** assuma responsabilidades dos *sub_agentes* especializados
 
-- **SILÊNCIO** completo durante ANALYSIS_PROCEDURE até conclusão  
-- Para “fora de escopo”, responda educadamente sem acionar *sub_agentes*  
-- Em “falhas”: informe claramente o problema ao usuário  
-- **JAMAIS** exponha dados brutos ou não anonimizados  
+- **SILÊNCIO** completo durante ANALYSIS_PROCEDURE até conclusão
+- Para “fora de escopo”, responda educadamente sem acionar *sub_agentes*
+- Em “falhas”: informe claramente o problema ao usuário
+- Sempre que faltarem dados ou pré-requisitos, comunique o usuário sobre
+  o bloqueio e indique as ações necessárias (coletar dados, revisar
+  datas/canais/objetivos) antes de prosseguir.
+- **JAMAIS** exponha dados brutos ou não anonimizados
 
 - Após concluir a análise e entregar ao usuário, se ele solicitar **uma nova análise**, siga:
    - Envie OBRIGATORIAMENTE um request ao *planner_agent* com a mensagem “resetar plano de tarefas”


### PR DESCRIPTION
## Summary
- clarify the supervisor prompt to require `ensure_next_task_ready` checks and remediation guidance before delegating data or analysis tasks
- add an `ensure_next_task_ready` tool that blocks downstream agents until prerequisite clarification and data collection steps are completed
- expose the new guardrail in the supervisor toolset and extend plan management tests to cover blocked and ready scenarios

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d560c796f48322b08c263ec124934d